### PR TITLE
Mainly for compare and contrast. 

### DIFF
--- a/max6951_m1geo.v
+++ b/max6951_m1geo.v
@@ -21,220 +21,88 @@ module max6951_m1geo
     input resetn,      // negative edge async reset
     input [31:0] data, // to display. 0xDEADBEEF will put DEADBEEF on the display
     input [7:0] dps,   // display 7:0 decimal points.
-    output reg DI_nCS, //
-    output reg DI_DTA, // 3 lines to display controller
-    output reg DI_CKS  //
+    output DI_nCS, //
+    output DI_DTA, // 3 lines to display controller
+    output DI_CKS  //
     );
     
     ////
-    //// Slow Clock (div 4)
+    //// Slow Clock (div 8)
     ////   slow_clock must be less 26 MHz. See datasheet for timings. 
     ////
     wire slow_clock;
-    reg [1:0] clk_div;
+    reg [2:0] clk_div;
     always @(posedge clk or negedge resetn) begin
         if (~resetn)
             clk_div <= 'b0;
         else
             clk_div <= clk_div + 1'b1;
     end
-    assign slow_clock = clk_div[1];
+    assign slow_clock = clk_div[2]; // Divided clock twice as much as that's what you were doing manually
     
+    // I like naming my state machine states
+    parameter s_IDLE = 0;
+    parameter s_SENDING = 1;
+    parameter s_DONE = 2;
+
     ////
     //// Bit FSM
     ////     Code toggles "update_data" when "reg_data" can be updated.
     ////     Use this 'clock' to run another FSM to setup the registers.
     ////
     reg [15:0] reg_data;        // data to write to the display
-    reg [15:0] reg_data_t;         // temporary, only updated when bit_fsm_counter is ready
-    reg [5:0] bit_fsm_counter;  // holds states.
-    reg update_data;
-    always @(posedge slow_clock or negedge resetn) begin
+    reg [15:0] reg_data_t;         // holds the current data being sent while sending, when idle holds the last value sent
+    reg [2:0] bit_fsm_state;  // holds states.
+    reg [3:0] r_bitCounter; //which bit is being currently sent
+    wire update_data;
+
+    // update_data pulsed high for a single slow clock cycle when data has finished sending
+    assign update_data = (bit_fsm_state == s_DONE);
+
+    // clock is clocking out data as long as we are not idle
+    assign DI_CKS = (bit_fsm_state == s_SENDING);
+
+    // if we are sending, send the data bit indicated by r_bitCounter, otherwise send 0
+    assign DI_DTA = (bit_fsm_state == s_SENDING) ? reg_data_t[r_bitCounter]: 1'b0;
+
+
+    always @(negedge slow_clock or negedge resetn) begin
         if (~resetn) begin
-            bit_fsm_counter <= 'b0;
+            bit_fsm_state <= S_IDLE;
             reg_data_t <= 'b0;
         end else begin
-        if (bit_fsm_counter >= 33)
-            bit_fsm_counter <= 'b0;
-        else
-            bit_fsm_counter <= bit_fsm_counter + 1'b1;
-        end
         
-        case (bit_fsm_counter)
-            default : begin // reset state, ensure clock low
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b1;
-                DI_DTA <= 1'b0;
-                reg_data_t <= reg_data;
-                update_data <= 1'b0;
-            end
-            1 : begin // take low low, set data 15
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[15];
-            end
-            2 : begin // clock in data 15
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[15];
-            end
-            3 : begin // take low low, set data 14
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[14];
-            end
-            4 : begin // clock in data 14
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[14];
-            end
-            5 : begin // take low low, set data 13
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[13];
-            end
-            6 : begin // clock in data 13
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[13];
-            end
-            7 : begin // take low low, set data 12
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[12];
-            end
-            8 : begin // clock in data 12
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[12];
-            end
-            9 : begin // take low low, set data 11
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[11];
-            end
-            10 : begin // clock in data 11
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[11];
-            end
-            11 : begin // take low low, set data 10
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[10];
-            end
-            12 : begin // clock in data 10
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[10];
-            end
-            13 : begin // take low low, set data 9
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[9];
-            end
-            14 : begin // clock in data 9
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[9];
-            end
-            15 : begin // take low low, set data 8
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[8];
-            end
-            16 : begin // clock in data 8
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[8];
-            end
-            17 : begin // take low low, set data 7
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[7];
-            end
-            18 : begin // clock in data 7
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[7];
-            end
-            19 : begin // take low low, set data 6
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[6];
-            end
-            20 : begin // clock in data 6
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[6];
-            end
-            21 : begin // take low low, set data 5
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[5];
-            end
-            22 : begin // clock in data 5
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[5];
-            end
-            23 : begin // take low low, set data 4
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[4];
-            end
-            24 : begin // clock in data 4
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[4];
-            end
-            25 : begin // take low low, set data 3
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[3];
-            end
-            26 : begin // clock in data 3
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[3];
-            end
-            27 : begin // take low low, set data 2
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[2];
-            end
-            28 : begin // clock in data 2
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[2];
-            end
-            29 : begin // take low low, set data 1
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[1];
-            end
-            30 : begin // clock in data 1
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[1];
-            end
-            31 : begin // take low low, set data 0
-                DI_CKS <= 1'b0;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[0];
-            end
-            32 : begin // clock in data 0
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b0;
-                DI_DTA <= reg_data_t[0];
-            end
-            33 : begin // latch data in, nCS high
-                DI_CKS <= 1'b1;
-                DI_nCS <= 1'b1;
-                DI_DTA <= 1'b0;
-                update_data <= 1'b1;
-            end
-        endcase
+            case (bit_fsm_state)
+                s_IDLE: begin
+                    if (reg_data != reg_data_t) begin
+                        // We have new data to send
+                        reg_data_t <= reg_data;
+                        bit_fsm_state <= s_SENDING; 
+                        r_bitCounter <= 4'd15;
+                    end else begin
+                        reg_data_t <= reg_data_t;
+                        bit_fsm_state <= s_IDLE;
+                        r_bitCounter <= 4'b0;
+                    end
+                end
+
+                s_SENDING: begin
+                    if (r_bitCounter == 0) begin
+                        bit_fsm_state <= s_DONE;
+                        r_bitCounter <= 4'b0;
+                    end else begin
+                        bit_fsm_state <= s_SENDING;
+                        r_bitCounter <= r_bitCounter - 1;
+                    end
+                end
+
+                s_DONE: begin
+                    // single iteration in this state to pulse update_data
+                    bit_fsm_state <= s_IDLE;
+                end
+
+            endcase
+        end
     end
     
     ////

--- a/max6951_m1geo_testbench.v
+++ b/max6951_m1geo_testbench.v
@@ -1,0 +1,55 @@
+`timescale 1ns / 1ps
+//////////////////////////////////////////////////////////////////////////////////
+// Company: 
+// Engineer: 
+// 
+// Create Date: 18.08.2019 22:17:16
+// Design Name: 
+// Module Name: testbench
+// Project Name: 
+// Target Devices: 
+// Tool Versions: 
+// Description: 
+// 
+// Dependencies: 
+// 
+// Revision:
+// Revision 0.01 - File Created
+// Additional Comments:
+// 
+//////////////////////////////////////////////////////////////////////////////////
+
+
+module testbench;
+    reg clk = 0;         // 66.6667 MHz positive edge
+    reg resetn = 1;      // negative edge async reset
+    reg [31:0] data = 0; // to display. 0xDEADBEEF will put DEADBEEF on the display
+    reg [7:0] dps = 0;   // display 7:0 decimal points.
+    wire DI_nCS; //
+    wire DI_DTA; // 3 lines to display controller
+    wire DI_CKS;  //
+    
+// UUT
+max6951_m1geo uut (
+    .clk(clk),
+    .resetn(resetn),
+    .data(data),
+    .dps(dps),
+    .DI_nCS(DI_nCS),
+    .DI_DTA(DI_DTA),
+    .DI_CKS(DI_CKS)
+);
+
+parameter MAX_CLOCKS = 100000;
+integer i = 0;
+
+initial begin
+    #5 resetn = 0;
+    #5 resetn = 1;
+    for(i=0; i<MAX_CLOCKS; i= i+1)
+        #1 clk = ~clk;
+     
+    $finish;
+end
+    
+endmodule

--- a/testbench.v
+++ b/testbench.v
@@ -1,0 +1,1 @@
+/home/dan/scratchpad/scratchpad.srcs/sim_1/new/testbench.v

--- a/testbench.v
+++ b/testbench.v
@@ -1,1 +1,0 @@
-/home/dan/scratchpad/scratchpad.srcs/sim_1/new/testbench.v


### PR DESCRIPTION
Was interested in some the things you did. I would have done it quite differently. I've submitted my version as I would be interested why a proper FPGA guy would do things so differently to me!
Passes in testbench (attached), not tested in hardware. Seems to be something a bit dodgy on reset where it either sends 0x04, 0x01 twice (if ctrl_fsm_counter is initialised to 0) or 0x60, 0x8F (Error) before sending (0x04, 0x01) if ctrl_fsm_counter is not initialised. Looks to be fine after that. I've only looked at the actual SPI bit banging, haven't touched the bit that converts from hex to SPI values
![vivado_testbench](https://user-images.githubusercontent.com/12901004/63230933-3c629300-c20c-11e9-8b08-78384e428b5c.PNG)

